### PR TITLE
Update README links for the node-12 compatible repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 node-ffi
 ========
 ### Node.js Foreign Function Interface
-[![Build Status](https://travis-ci.org/node-ffi/node-ffi.svg?branch=master)](https://travis-ci.org/node-ffi/node-ffi)
-[![Build Status](https://ci.appveyor.com/api/projects/status/n81apam1igfw8491?svg=true)](https://ci.appveyor.com/project/TooTallNate/node-ffi)
+[![Build Status](https://travis-ci.org/lxe/node-ffi.svg?branch=node-12)](https://travis-ci.org/lxe/node-ffi)
 
 `node-ffi` is a Node.js addon for loading and calling dynamic libraries using
 pure JavaScript. It can be used to create bindings to native libraries without
@@ -68,7 +67,7 @@ $ npm install -g node-gyp
 Now you can compile `node-ffi`:
 
 ``` bash
-$ git clone git://github.com/node-ffi/node-ffi.git
+$ git clone git://github.com/lxe/node-ffi.git
 $ cd node-ffi
 $ node-gyp rebuild
 ```
@@ -103,6 +102,6 @@ License
 
 MIT License. See the `LICENSE` file.
 
-[v1apichanges]: https://github.com/node-ffi/node-ffi/wiki/API-changes-from-v0.x-to-v1.x
-[tutorial]: https://github.com/node-ffi/node-ffi/wiki/Node-FFI-Tutorial
+[v1apichanges]: https://github.com/lxe/node-ffi/wiki/API-changes-from-v0.x-to-v1.x
+[tutorial]: https://github.com/lxe/node-ffi/wiki/Node-FFI-Tutorial
 [ref-types]: https://github.com/TooTallNate/ref#built-in-types


### PR DESCRIPTION
I removed the Appveyor link as I'm not familiar with the tool, but kept & updated Travis-CI as I'm guessing enabling it for this project would be fairly simple.